### PR TITLE
Revert logo designs to v3.007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Sans Flex Changelog
 
+## Version 4.004 (2026-03-26)
+
+### Changed
+- reverted logo glyphs to their deisng from v3.007
+
+
 ## Version 4.003 (2026-02-25)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 4.004 (2026-03-26)
 
 ### Changed
-- reverted logo glyphs to their deisng from v3.007
+- reverted logo glyphs to their design from v3.007
 
 
 ## Version 4.003 (2026-02-25)

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -235,7 +235,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -235,7 +235,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -143,7 +143,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -211,7 +211,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -143,7 +143,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -207,7 +207,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -143,7 +143,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -211,7 +211,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -211,7 +211,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -165,7 +165,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -165,7 +165,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -165,7 +165,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -165,7 +165,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -301,7 +301,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -301,7 +301,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -287,7 +287,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -279,7 +279,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -287,7 +287,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -287,7 +287,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -287,7 +287,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -165,7 +165,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -287,7 +287,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -297,7 +297,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -151,7 +151,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -151,7 +151,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -151,7 +151,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="830" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1038" y="-35"/>
-      <point x="1357" y="141"/>
-      <point x="1531" y="464"/>
-      <point x="1531" y="674" type="qcurve" smooth="yes"/>
-      <point x="1531" y="728"/>
-      <point x="1521" y="794" type="qcurve"/>
-      <point x="827" y="794" type="line"/>
-      <point x="827" y="587" type="line"/>
-      <point x="1314" y="587" type="line"/>
-      <point x="1301" y="454"/>
-      <point x="1173" y="268"/>
-      <point x="966" y="175"/>
-      <point x="835" y="175" type="qcurve" smooth="yes"/>
-      <point x="688" y="175"/>
-      <point x="452" y="313"/>
-      <point x="316" y="560"/>
-      <point x="316" y="717" type="qcurve" smooth="yes"/>
-      <point x="316" y="878"/>
-      <point x="453" y="1123"/>
-      <point x="689" y="1255"/>
-      <point x="835" y="1255" type="qcurve" smooth="yes"/>
-      <point x="950" y="1255"/>
-      <point x="1129" y="1179"/>
-      <point x="1214" y="1092" type="qcurve"/>
-      <point x="1359" y="1244" type="line"/>
-      <point x="1264" y="1356"/>
-      <point x="994" y="1464"/>
-      <point x="832" y="1464" type="qcurve" smooth="yes"/>
-      <point x="624" y="1464"/>
-      <point x="284" y="1269"/>
-      <point x="90" y="929"/>
-      <point x="90" y="720" type="qcurve" smooth="yes"/>
-      <point x="90" y="514"/>
-      <point x="285" y="170"/>
-      <point x="624" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1004" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1357" y="-82"/>
-      <point x="1802" y="373"/>
-      <point x="1802" y="730" type="qcurve" smooth="yes"/>
-      <point x="1802" y="776"/>
-      <point x="1794" y="859"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902"/>
-      <point x="1787" y="902" type="qcurve"/>
-      <point x="1003" y="902" type="line"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902"/>
-      <point x="1003" y="902" type="qcurve"/>
-      <point x="1003" y="579" type="line"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579"/>
-      <point x="1003" y="579" type="qcurve"/>
-      <point x="1451" y="579" type="line"/>
-      <point x="1425" y="435"/>
-      <point x="1180" y="248"/>
-      <point x="1005" y="248" type="qcurve" smooth="yes"/>
-      <point x="799" y="248"/>
-      <point x="510" y="550"/>
-      <point x="510" y="750" type="qcurve" smooth="yes"/>
-      <point x="510" y="948"/>
-      <point x="798" y="1250"/>
-      <point x="1002" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1100" y="1250"/>
-      <point x="1263" y="1183"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127"/>
-      <point x="1321" y="1127" type="qcurve"/>
-      <point x="1560" y="1364" type="line"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364"/>
-      <point x="1560" y="1364" type="qcurve"/>
-      <point x="1452" y="1466"/>
-      <point x="1171" y="1582"/>
-      <point x="1004" y="1582" type="qcurve" smooth="yes"/>
-      <point x="657" y="1582"/>
-      <point x="172" y="1089"/>
-      <point x="172" y="750" type="qcurve" smooth="yes"/>
-      <point x="172" y="411"/>
-      <point x="654" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="585" y="-31" type="qcurve" smooth="yes"/>
-      <point x="730" y="-31"/>
-      <point x="966" y="106"/>
-      <point x="1034" y="218" type="qcurve" smooth="yes"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218"/>
-      <point x="1034" y="218" type="qcurve"/>
-      <point x="872" y="324" type="line"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324"/>
-      <point x="872" y="324" type="qcurve" smooth="yes"/>
-      <point x="819" y="250"/>
-      <point x="677" y="168"/>
-      <point x="595" y="168" type="qcurve" smooth="yes"/>
-      <point x="458" y="168"/>
-      <point x="266" y="374"/>
-      <point x="266" y="520" type="qcurve"/>
-      <point x="266" y="520" type="line"/>
-      <point x="266" y="675"/>
-      <point x="432" y="866"/>
-      <point x="572" y="866" type="qcurve" smooth="yes"/>
-      <point x="654" y="866"/>
-      <point x="789" y="770"/>
-      <point x="827" y="663" type="qcurve"/>
-      <point x="846" y="754" type="line"/>
-      <point x="167" y="466" type="line"/>
-      <point x="224" y="301" type="line"/>
-      <point x="1044" y="649" type="line" smooth="yes"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649"/>
-      <point x="1044" y="649" type="qcurve"/>
-      <point x="1040" y="672"/>
-      <point x="1030" y="708"/>
-      <point x="1024" y="725" type="qcurve" smooth="yes"/>
-      <point x="959" y="893"/>
-      <point x="734" y="1051"/>
-      <point x="580" y="1051" type="qcurve" smooth="yes"/>
-      <point x="345" y="1051"/>
-      <point x="54" y="744"/>
-      <point x="54" y="507" type="qcurve"/>
-      <point x="54" y="507" type="line"/>
-      <point x="54" y="265"/>
-      <point x="355" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="554" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1062" y="-464"/>
-      <point x="1062" y="118" type="qcurve" smooth="yes"/>
-      <point x="1062" y="1020" type="line"/>
-      <point x="854" y="1020" type="line"/>
-      <point x="854" y="893" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="801" y="969"/>
-      <point x="627" y="1051"/>
-      <point x="523" y="1051" type="qcurve" smooth="yes"/>
-      <point x="377" y="1051"/>
-      <point x="158" y="913"/>
-      <point x="40" y="670"/>
-      <point x="40" y="517" type="qcurve" smooth="yes"/>
-      <point x="40" y="362"/>
-      <point x="158" y="123"/>
-      <point x="380" y="-11"/>
-      <point x="531" y="-11" type="qcurve" smooth="yes"/>
-      <point x="607" y="-11"/>
-      <point x="735" y="40"/>
-      <point x="823" y="113"/>
-      <point x="847" y="149" type="qcurve"/>
-      <point x="854" y="149" type="line"/>
-      <point x="854" y="56" type="line" smooth="yes"/>
-      <point x="854" y="-98"/>
-      <point x="699" y="-270"/>
-      <point x="551" y="-270" type="qcurve" smooth="yes"/>
-      <point x="454" y="-270"/>
-      <point x="320" y="-169"/>
-      <point x="273" y="-80" type="qcurve"/>
-      <point x="85" y="-163" type="line"/>
-      <point x="159" y="-320"/>
-      <point x="382" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="554" y="187" type="qcurve" smooth="yes"/>
-      <point x="467" y="187"/>
-      <point x="331" y="267"/>
-      <point x="254" y="419"/>
-      <point x="254" y="523" type="qcurve" smooth="yes"/>
-      <point x="254" y="622"/>
-      <point x="330" y="774"/>
-      <point x="466" y="857"/>
-      <point x="555" y="857" type="qcurve" smooth="yes"/>
-      <point x="646" y="857"/>
-      <point x="782" y="775"/>
-      <point x="854" y="624"/>
-      <point x="854" y="524" type="qcurve" smooth="yes"/>
-      <point x="854" y="426"/>
-      <point x="782" y="273"/>
-      <point x="646" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="136" y="0" type="line"/>
-      <point x="354" y="0" type="line"/>
-      <point x="354" y="1432" type="line"/>
-      <point x="136" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="584" y="-33" type="qcurve" smooth="yes"/>
-      <point x="739" y="-33"/>
-      <point x="984" y="108"/>
-      <point x="1122" y="358"/>
-      <point x="1122" y="514" type="qcurve" smooth="yes"/>
-      <point x="1122" y="671"/>
-      <point x="982" y="919"/>
-      <point x="737" y="1057"/>
-      <point x="584" y="1057" type="qcurve" smooth="yes"/>
-      <point x="433" y="1057"/>
-      <point x="189" y="921"/>
-      <point x="48" y="674"/>
-      <point x="48" y="514" type="qcurve" smooth="yes"/>
-      <point x="48" y="358"/>
-      <point x="185" y="109"/>
-      <point x="430" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="584" y="157" type="qcurve" smooth="yes"/>
-      <point x="489" y="157"/>
-      <point x="342" y="253"/>
-      <point x="261" y="416"/>
-      <point x="261" y="514" type="qcurve" smooth="yes"/>
-      <point x="261" y="616"/>
-      <point x="348" y="777"/>
-      <point x="496" y="867"/>
-      <point x="584" y="867" type="qcurve" smooth="yes"/>
-      <point x="678" y="867"/>
-      <point x="826" y="773"/>
-      <point x="907" y="612"/>
-      <point x="907" y="514" type="qcurve" smooth="yes"/>
-      <point x="907" y="415"/>
-      <point x="826" y="252"/>
-      <point x="679" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -151,7 +151,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>998</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -163,7 +163,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -155,7 +155,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -163,7 +163,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="824" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1032" y="-35"/>
-      <point x="1351" y="141"/>
-      <point x="1525" y="464"/>
-      <point x="1525" y="674" type="qcurve" smooth="yes"/>
-      <point x="1525" y="728"/>
-      <point x="1515" y="794" type="qcurve"/>
-      <point x="821" y="794" type="line"/>
-      <point x="821" y="587" type="line"/>
-      <point x="1308" y="587" type="line"/>
-      <point x="1295" y="454"/>
-      <point x="1167" y="268"/>
-      <point x="960" y="175"/>
-      <point x="829" y="175" type="qcurve" smooth="yes"/>
-      <point x="682" y="175"/>
-      <point x="446" y="313"/>
-      <point x="310" y="560"/>
-      <point x="310" y="717" type="qcurve" smooth="yes"/>
-      <point x="310" y="878"/>
-      <point x="447" y="1123"/>
-      <point x="683" y="1255"/>
-      <point x="829" y="1255" type="qcurve" smooth="yes"/>
-      <point x="944" y="1255"/>
-      <point x="1123" y="1179"/>
-      <point x="1208" y="1092" type="qcurve"/>
-      <point x="1353" y="1244" type="line"/>
-      <point x="1258" y="1356"/>
-      <point x="988" y="1464"/>
-      <point x="826" y="1464" type="qcurve" smooth="yes"/>
-      <point x="618" y="1464"/>
-      <point x="278" y="1269"/>
-      <point x="84" y="929"/>
-      <point x="84" y="720" type="qcurve" smooth="yes"/>
-      <point x="84" y="514"/>
-      <point x="279" y="170"/>
-      <point x="618" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6540"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2754"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5004"/>
-    <component base="e.logo" xOffset="5417"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="579" y="-31" type="qcurve" smooth="yes"/>
-      <point x="724" y="-31"/>
-      <point x="960" y="106"/>
-      <point x="1028" y="218" type="qcurve" smooth="yes"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218"/>
-      <point x="1028" y="218" type="qcurve"/>
-      <point x="866" y="324" type="line"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324"/>
-      <point x="866" y="324" type="qcurve" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="671" y="168"/>
-      <point x="589" y="168" type="qcurve" smooth="yes"/>
-      <point x="452" y="168"/>
-      <point x="260" y="374"/>
-      <point x="260" y="520" type="qcurve"/>
-      <point x="260" y="520" type="line"/>
-      <point x="260" y="675"/>
-      <point x="426" y="866"/>
-      <point x="566" y="866" type="qcurve" smooth="yes"/>
-      <point x="648" y="866"/>
-      <point x="783" y="770"/>
-      <point x="821" y="663" type="qcurve"/>
-      <point x="840" y="754" type="line"/>
-      <point x="161" y="466" type="line"/>
-      <point x="218" y="301" type="line"/>
-      <point x="1038" y="649" type="line" smooth="yes"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649"/>
-      <point x="1038" y="649" type="qcurve"/>
-      <point x="1034" y="672"/>
-      <point x="1024" y="708"/>
-      <point x="1018" y="725" type="qcurve" smooth="yes"/>
-      <point x="953" y="893"/>
-      <point x="728" y="1051"/>
-      <point x="574" y="1051" type="qcurve" smooth="yes"/>
-      <point x="339" y="1051"/>
-      <point x="48" y="744"/>
-      <point x="48" y="507" type="qcurve"/>
-      <point x="48" y="507" type="line"/>
-      <point x="48" y="265"/>
-      <point x="349" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1086"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="548" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1056" y="-464"/>
-      <point x="1056" y="118" type="qcurve" smooth="yes"/>
-      <point x="1056" y="1020" type="line"/>
-      <point x="848" y="1020" type="line"/>
-      <point x="848" y="893" type="line"/>
-      <point x="844" y="893" type="line"/>
-      <point x="795" y="969"/>
-      <point x="621" y="1051"/>
-      <point x="517" y="1051" type="qcurve" smooth="yes"/>
-      <point x="371" y="1051"/>
-      <point x="152" y="913"/>
-      <point x="34" y="670"/>
-      <point x="34" y="517" type="qcurve" smooth="yes"/>
-      <point x="34" y="362"/>
-      <point x="152" y="123"/>
-      <point x="374" y="-11"/>
-      <point x="525" y="-11" type="qcurve" smooth="yes"/>
-      <point x="601" y="-11"/>
-      <point x="729" y="40"/>
-      <point x="817" y="113"/>
-      <point x="841" y="149" type="qcurve"/>
-      <point x="848" y="149" type="line"/>
-      <point x="848" y="56" type="line" smooth="yes"/>
-      <point x="848" y="-98"/>
-      <point x="693" y="-270"/>
-      <point x="545" y="-270" type="qcurve" smooth="yes"/>
-      <point x="448" y="-270"/>
-      <point x="314" y="-169"/>
-      <point x="267" y="-80" type="qcurve"/>
-      <point x="79" y="-163" type="line"/>
-      <point x="153" y="-320"/>
-      <point x="376" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="548" y="187" type="qcurve" smooth="yes"/>
-      <point x="461" y="187"/>
-      <point x="325" y="267"/>
-      <point x="248" y="419"/>
-      <point x="248" y="523" type="qcurve" smooth="yes"/>
-      <point x="248" y="622"/>
-      <point x="324" y="774"/>
-      <point x="460" y="857"/>
-      <point x="549" y="857" type="qcurve" smooth="yes"/>
-      <point x="640" y="857"/>
-      <point x="776" y="775"/>
-      <point x="848" y="624"/>
-      <point x="848" y="524" type="qcurve" smooth="yes"/>
-      <point x="848" y="426"/>
-      <point x="776" y="273"/>
-      <point x="640" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="578" y="-33" type="qcurve" smooth="yes"/>
-      <point x="733" y="-33"/>
-      <point x="978" y="108"/>
-      <point x="1116" y="358"/>
-      <point x="1116" y="514" type="qcurve" smooth="yes"/>
-      <point x="1116" y="671"/>
-      <point x="976" y="919"/>
-      <point x="731" y="1057"/>
-      <point x="578" y="1057" type="qcurve" smooth="yes"/>
-      <point x="427" y="1057"/>
-      <point x="183" y="921"/>
-      <point x="42" y="674"/>
-      <point x="42" y="514" type="qcurve" smooth="yes"/>
-      <point x="42" y="358"/>
-      <point x="179" y="109"/>
-      <point x="424" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="578" y="157" type="qcurve" smooth="yes"/>
-      <point x="483" y="157"/>
-      <point x="336" y="253"/>
-      <point x="255" y="416"/>
-      <point x="255" y="514" type="qcurve" smooth="yes"/>
-      <point x="255" y="616"/>
-      <point x="342" y="777"/>
-      <point x="490" y="867"/>
-      <point x="578" y="867" type="qcurve" smooth="yes"/>
-      <point x="672" y="867"/>
-      <point x="820" y="773"/>
-      <point x="901" y="612"/>
-      <point x="901" y="514" type="qcurve" smooth="yes"/>
-      <point x="901" y="415"/>
-      <point x="820" y="252"/>
-      <point x="673" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -155,7 +155,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1066</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -253,7 +253,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -245,7 +245,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -253,7 +253,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -245,7 +245,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -253,7 +253,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -245,7 +245,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -253,7 +253,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -245,7 +245,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -261,7 +261,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -213,7 +213,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -261,7 +261,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -213,7 +213,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -255,7 +255,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -243,7 +243,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -251,7 +251,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -243,7 +243,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -255,7 +255,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -243,7 +243,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -251,7 +251,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -243,7 +243,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -221,7 +221,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -221,7 +221,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,52 +3,36 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="580" y="-31" type="qcurve" smooth="yes"/>
-      <point x="725" y="-31"/>
-      <point x="961" y="106"/>
-      <point x="1029" y="218" type="qcurve" smooth="yes"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218"/>
-      <point x="1029" y="218" type="qcurve"/>
-      <point x="867" y="324" type="line"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324"/>
-      <point x="867" y="324" type="qcurve" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="672" y="168"/>
-      <point x="590" y="168" type="qcurve" smooth="yes"/>
-      <point x="453" y="168"/>
-      <point x="261" y="374"/>
-      <point x="261" y="520" type="qcurve"/>
-      <point x="261" y="520" type="line"/>
-      <point x="261" y="675"/>
-      <point x="427" y="866"/>
-      <point x="567" y="866" type="qcurve" smooth="yes"/>
-      <point x="649" y="866"/>
-      <point x="784" y="770"/>
-      <point x="822" y="663" type="qcurve"/>
-      <point x="841" y="754" type="line"/>
-      <point x="162" y="466" type="line"/>
-      <point x="219" y="301" type="line"/>
-      <point x="1039" y="649" type="line" smooth="yes"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649"/>
-      <point x="1039" y="649" type="qcurve"/>
-      <point x="1035" y="672"/>
-      <point x="1025" y="708"/>
-      <point x="1019" y="725" type="qcurve" smooth="yes"/>
-      <point x="954" y="893"/>
-      <point x="729" y="1051"/>
-      <point x="575" y="1051" type="qcurve" smooth="yes"/>
-      <point x="340" y="1051"/>
-      <point x="49" y="744"/>
-      <point x="49" y="507" type="qcurve"/>
-      <point x="49" y="507" type="line"/>
-      <point x="49" y="265"/>
-      <point x="350" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="549" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1057" y="-464"/>
-      <point x="1057" y="118" type="qcurve" smooth="yes"/>
-      <point x="1057" y="1020" type="line"/>
-      <point x="849" y="1020" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="845" y="893" type="line"/>
-      <point x="796" y="969"/>
-      <point x="622" y="1051"/>
-      <point x="518" y="1051" type="qcurve" smooth="yes"/>
-      <point x="372" y="1051"/>
-      <point x="153" y="913"/>
-      <point x="35" y="670"/>
-      <point x="35" y="517" type="qcurve" smooth="yes"/>
-      <point x="35" y="362"/>
-      <point x="153" y="123"/>
-      <point x="375" y="-11"/>
-      <point x="526" y="-11" type="qcurve" smooth="yes"/>
-      <point x="602" y="-11"/>
-      <point x="730" y="40"/>
-      <point x="818" y="113"/>
-      <point x="842" y="149" type="qcurve"/>
-      <point x="849" y="149" type="line"/>
-      <point x="849" y="56" type="line" smooth="yes"/>
-      <point x="849" y="-98"/>
-      <point x="694" y="-270"/>
-      <point x="546" y="-270" type="qcurve" smooth="yes"/>
-      <point x="449" y="-270"/>
-      <point x="315" y="-169"/>
-      <point x="268" y="-80" type="qcurve"/>
-      <point x="80" y="-163" type="line"/>
-      <point x="154" y="-320"/>
-      <point x="377" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="549" y="187" type="qcurve" smooth="yes"/>
-      <point x="462" y="187"/>
-      <point x="326" y="267"/>
-      <point x="249" y="419"/>
-      <point x="249" y="523" type="qcurve" smooth="yes"/>
-      <point x="249" y="622"/>
-      <point x="325" y="774"/>
-      <point x="461" y="857"/>
-      <point x="550" y="857" type="qcurve" smooth="yes"/>
-      <point x="641" y="857"/>
-      <point x="777" y="775"/>
-      <point x="849" y="624"/>
-      <point x="849" y="524" type="qcurve" smooth="yes"/>
-      <point x="849" y="426"/>
-      <point x="777" y="273"/>
-      <point x="641" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="130" y="0" type="line"/>
-      <point x="348" y="0" type="line"/>
-      <point x="348" y="1432" type="line"/>
-      <point x="130" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -293,7 +293,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -173,7 +173,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -173,7 +173,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -173,7 +173,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -173,7 +173,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1591"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="827" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1035" y="-35"/>
-      <point x="1354" y="141"/>
-      <point x="1528" y="464"/>
-      <point x="1528" y="674" type="qcurve" smooth="yes"/>
-      <point x="1528" y="728"/>
-      <point x="1518" y="794" type="qcurve"/>
-      <point x="824" y="794" type="line"/>
-      <point x="824" y="587" type="line"/>
-      <point x="1311" y="587" type="line"/>
-      <point x="1298" y="454"/>
-      <point x="1170" y="268"/>
-      <point x="963" y="175"/>
-      <point x="832" y="175" type="qcurve" smooth="yes"/>
-      <point x="685" y="175"/>
-      <point x="449" y="313"/>
-      <point x="313" y="560"/>
-      <point x="313" y="717" type="qcurve" smooth="yes"/>
-      <point x="313" y="878"/>
-      <point x="450" y="1123"/>
-      <point x="686" y="1255"/>
-      <point x="832" y="1255" type="qcurve" smooth="yes"/>
-      <point x="947" y="1255"/>
-      <point x="1126" y="1179"/>
-      <point x="1211" y="1092" type="qcurve"/>
-      <point x="1356" y="1244" type="line"/>
-      <point x="1261" y="1356"/>
-      <point x="991" y="1464"/>
-      <point x="829" y="1464" type="qcurve" smooth="yes"/>
-      <point x="621" y="1464"/>
-      <point x="281" y="1269"/>
-      <point x="87" y="929"/>
-      <point x="87" y="720" type="qcurve" smooth="yes"/>
-      <point x="87" y="514"/>
-      <point x="282" y="170"/>
-      <point x="621" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -3,51 +3,35 @@
   <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1001" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1354" y="-82"/>
-      <point x="1799" y="373"/>
-      <point x="1799" y="730" type="qcurve" smooth="yes"/>
-      <point x="1799" y="776"/>
-      <point x="1791" y="859"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902"/>
-      <point x="1784" y="902" type="qcurve"/>
-      <point x="1000" y="902" type="line"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902"/>
-      <point x="1000" y="902" type="qcurve"/>
-      <point x="1000" y="579" type="line"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579"/>
-      <point x="1000" y="579" type="qcurve"/>
-      <point x="1448" y="579" type="line"/>
-      <point x="1422" y="435"/>
-      <point x="1177" y="248"/>
-      <point x="1002" y="248" type="qcurve" smooth="yes"/>
-      <point x="796" y="248"/>
-      <point x="507" y="550"/>
-      <point x="507" y="750" type="qcurve" smooth="yes"/>
-      <point x="507" y="948"/>
-      <point x="795" y="1250"/>
-      <point x="999" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1097" y="1250"/>
-      <point x="1260" y="1183"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127"/>
-      <point x="1318" y="1127" type="qcurve"/>
-      <point x="1557" y="1364" type="line"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364"/>
-      <point x="1557" y="1364" type="qcurve"/>
-      <point x="1449" y="1466"/>
-      <point x="1168" y="1582"/>
-      <point x="1001" y="1582" type="qcurve" smooth="yes"/>
-      <point x="654" y="1582"/>
-      <point x="169" y="1089"/>
-      <point x="169" y="750" type="qcurve" smooth="yes"/>
-      <point x="169" y="411"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
       <point x="651" y="-82"/>
     </contour>
   </outline>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6541"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1591"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3919"/>
-    <component base="l.logo" xOffset="5006"/>
-    <component base="e.logo" xOffset="5418"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="582" y="-31" type="qcurve" smooth="yes"/>
-      <point x="727" y="-31"/>
-      <point x="963" y="106"/>
-      <point x="1031" y="218" type="qcurve" smooth="yes"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218"/>
-      <point x="1031" y="218" type="qcurve"/>
-      <point x="869" y="324" type="line"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324"/>
-      <point x="869" y="324" type="qcurve" smooth="yes"/>
-      <point x="816" y="250"/>
-      <point x="674" y="168"/>
-      <point x="592" y="168" type="qcurve" smooth="yes"/>
-      <point x="455" y="168"/>
-      <point x="263" y="374"/>
-      <point x="263" y="520" type="qcurve"/>
-      <point x="263" y="520" type="line"/>
-      <point x="263" y="675"/>
-      <point x="429" y="866"/>
-      <point x="569" y="866" type="qcurve" smooth="yes"/>
-      <point x="651" y="866"/>
-      <point x="786" y="770"/>
-      <point x="824" y="663" type="qcurve"/>
-      <point x="843" y="754" type="line"/>
-      <point x="164" y="466" type="line"/>
-      <point x="221" y="301" type="line"/>
-      <point x="1041" y="649" type="line" smooth="yes"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649"/>
-      <point x="1041" y="649" type="qcurve"/>
-      <point x="1037" y="672"/>
-      <point x="1027" y="708"/>
-      <point x="1021" y="725" type="qcurve" smooth="yes"/>
-      <point x="956" y="893"/>
-      <point x="731" y="1051"/>
-      <point x="577" y="1051" type="qcurve" smooth="yes"/>
-      <point x="342" y="1051"/>
-      <point x="51" y="744"/>
-      <point x="51" y="507" type="qcurve"/>
-      <point x="51" y="507" type="line"/>
-      <point x="51" y="265"/>
-      <point x="352" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="551" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1059" y="-464"/>
-      <point x="1059" y="118" type="qcurve" smooth="yes"/>
-      <point x="1059" y="1020" type="line"/>
-      <point x="851" y="1020" type="line"/>
-      <point x="851" y="893" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="798" y="969"/>
-      <point x="624" y="1051"/>
-      <point x="520" y="1051" type="qcurve" smooth="yes"/>
-      <point x="374" y="1051"/>
-      <point x="155" y="913"/>
-      <point x="37" y="670"/>
-      <point x="37" y="517" type="qcurve" smooth="yes"/>
-      <point x="37" y="362"/>
-      <point x="155" y="123"/>
-      <point x="377" y="-11"/>
-      <point x="528" y="-11" type="qcurve" smooth="yes"/>
-      <point x="604" y="-11"/>
-      <point x="732" y="40"/>
-      <point x="820" y="113"/>
-      <point x="844" y="149" type="qcurve"/>
-      <point x="851" y="149" type="line"/>
-      <point x="851" y="56" type="line" smooth="yes"/>
-      <point x="851" y="-98"/>
-      <point x="696" y="-270"/>
-      <point x="548" y="-270" type="qcurve" smooth="yes"/>
-      <point x="451" y="-270"/>
-      <point x="317" y="-169"/>
-      <point x="270" y="-80" type="qcurve"/>
-      <point x="82" y="-163" type="line"/>
-      <point x="156" y="-320"/>
-      <point x="379" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="551" y="187" type="qcurve" smooth="yes"/>
-      <point x="464" y="187"/>
-      <point x="328" y="267"/>
-      <point x="251" y="419"/>
-      <point x="251" y="523" type="qcurve" smooth="yes"/>
-      <point x="251" y="622"/>
-      <point x="327" y="774"/>
-      <point x="463" y="857"/>
-      <point x="552" y="857" type="qcurve" smooth="yes"/>
-      <point x="643" y="857"/>
-      <point x="779" y="775"/>
-      <point x="851" y="624"/>
-      <point x="851" y="524" type="qcurve" smooth="yes"/>
-      <point x="851" y="426"/>
-      <point x="779" y="273"/>
-      <point x="643" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="412"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="350" y="0" type="line"/>
-      <point x="350" y="1432" type="line"/>
-      <point x="132" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1164"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="581" y="-33" type="qcurve" smooth="yes"/>
-      <point x="736" y="-33"/>
-      <point x="981" y="108"/>
-      <point x="1119" y="358"/>
-      <point x="1119" y="514" type="qcurve" smooth="yes"/>
-      <point x="1119" y="671"/>
-      <point x="979" y="919"/>
-      <point x="734" y="1057"/>
-      <point x="581" y="1057" type="qcurve" smooth="yes"/>
-      <point x="430" y="1057"/>
-      <point x="186" y="921"/>
-      <point x="45" y="674"/>
-      <point x="45" y="514" type="qcurve" smooth="yes"/>
-      <point x="45" y="358"/>
-      <point x="182" y="109"/>
-      <point x="427" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="581" y="157" type="qcurve" smooth="yes"/>
-      <point x="486" y="157"/>
-      <point x="339" y="253"/>
-      <point x="258" y="416"/>
-      <point x="258" y="514" type="qcurve" smooth="yes"/>
-      <point x="258" y="616"/>
-      <point x="345" y="777"/>
-      <point x="493" y="867"/>
-      <point x="581" y="867" type="qcurve" smooth="yes"/>
-      <point x="675" y="867"/>
-      <point x="823" y="773"/>
-      <point x="904" y="612"/>
-      <point x="904" y="514" type="qcurve" smooth="yes"/>
-      <point x="904" y="415"/>
-      <point x="823" y="252"/>
-      <point x="676" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1036</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -273,7 +273,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -225,7 +225,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -273,7 +273,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -263,7 +263,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -273,7 +273,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -263,7 +263,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -275,7 +275,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -263,7 +263,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -159,7 +159,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -199,7 +199,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -199,7 +199,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -251,7 +251,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -199,7 +199,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -145,7 +145,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -145,7 +145,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -145,7 +145,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -145,7 +145,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -291,7 +291,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -205,7 +205,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -281,7 +281,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -215,7 +215,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -283,7 +283,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -291,7 +291,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -195,7 +195,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -195,7 +195,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -291,7 +291,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -299,7 +299,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -195,7 +195,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -195,7 +195,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -175,7 +175,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -175,7 +175,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -175,7 +175,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -175,7 +175,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -301,7 +301,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -265,7 +265,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -265,7 +265,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -301,7 +301,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -301,7 +301,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="825" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1033" y="-35"/>
-      <point x="1352" y="141"/>
-      <point x="1526" y="464"/>
-      <point x="1526" y="674" type="qcurve" smooth="yes"/>
-      <point x="1526" y="728"/>
-      <point x="1516" y="794" type="qcurve"/>
-      <point x="822" y="794" type="line"/>
-      <point x="822" y="587" type="line"/>
-      <point x="1309" y="587" type="line"/>
-      <point x="1296" y="454"/>
-      <point x="1168" y="268"/>
-      <point x="961" y="175"/>
-      <point x="830" y="175" type="qcurve" smooth="yes"/>
-      <point x="683" y="175"/>
-      <point x="447" y="313"/>
-      <point x="311" y="560"/>
-      <point x="311" y="717" type="qcurve" smooth="yes"/>
-      <point x="311" y="878"/>
-      <point x="448" y="1123"/>
-      <point x="684" y="1255"/>
-      <point x="830" y="1255" type="qcurve" smooth="yes"/>
-      <point x="945" y="1255"/>
-      <point x="1124" y="1179"/>
-      <point x="1209" y="1092" type="qcurve"/>
-      <point x="1354" y="1244" type="line"/>
-      <point x="1259" y="1356"/>
-      <point x="989" y="1464"/>
-      <point x="827" y="1464" type="qcurve" smooth="yes"/>
-      <point x="619" y="1464"/>
-      <point x="279" y="1269"/>
-      <point x="85" y="929"/>
-      <point x="85" y="720" type="qcurve" smooth="yes"/>
-      <point x="85" y="514"/>
-      <point x="280" y="170"/>
-      <point x="619" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="999" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1352" y="-82"/>
-      <point x="1797" y="373"/>
-      <point x="1797" y="730" type="qcurve" smooth="yes"/>
-      <point x="1797" y="776"/>
-      <point x="1789" y="859"/>
-      <point x="1782" y="902" type="qcurve"/>
-      <point x="1782" y="902"/>
-      <point x="1782" y="902"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
       <point x="1782" y="902" type="qcurve"/>
       <point x="998" y="902" type="line"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902"/>
-      <point x="998" y="902" type="qcurve"/>
-      <point x="998" y="579" type="line"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579"/>
-      <point x="998" y="579" type="qcurve"/>
-      <point x="1446" y="579" type="line"/>
-      <point x="1420" y="435"/>
-      <point x="1175" y="248"/>
-      <point x="1000" y="248" type="qcurve" smooth="yes"/>
-      <point x="794" y="248"/>
-      <point x="505" y="550"/>
-      <point x="505" y="750" type="qcurve" smooth="yes"/>
-      <point x="505" y="948"/>
-      <point x="793" y="1250"/>
-      <point x="997" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1095" y="1250"/>
-      <point x="1258" y="1183"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127"/>
-      <point x="1316" y="1127" type="qcurve"/>
-      <point x="1555" y="1364" type="line"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364"/>
-      <point x="1555" y="1364" type="qcurve"/>
-      <point x="1447" y="1466"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
       <point x="1166" y="1582"/>
-      <point x="999" y="1582" type="qcurve" smooth="yes"/>
-      <point x="652" y="1582"/>
-      <point x="167" y="1089"/>
-      <point x="167" y="750" type="qcurve" smooth="yes"/>
-      <point x="167" y="411"/>
-      <point x="649" y="-82"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="581" y="-31" type="qcurve" smooth="yes"/>
-      <point x="726" y="-31"/>
-      <point x="962" y="106"/>
-      <point x="1030" y="218" type="qcurve" smooth="yes"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218"/>
-      <point x="1030" y="218" type="qcurve"/>
-      <point x="868" y="324" type="line"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324"/>
-      <point x="868" y="324" type="qcurve" smooth="yes"/>
-      <point x="815" y="250"/>
-      <point x="673" y="168"/>
-      <point x="591" y="168" type="qcurve" smooth="yes"/>
-      <point x="454" y="168"/>
-      <point x="262" y="374"/>
-      <point x="262" y="520" type="qcurve"/>
-      <point x="262" y="520" type="line"/>
-      <point x="262" y="675"/>
-      <point x="428" y="866"/>
-      <point x="568" y="866" type="qcurve" smooth="yes"/>
-      <point x="650" y="866"/>
-      <point x="785" y="770"/>
-      <point x="823" y="663" type="qcurve"/>
-      <point x="842" y="754" type="line"/>
-      <point x="163" y="466" type="line"/>
-      <point x="220" y="301" type="line"/>
-      <point x="1040" y="649" type="line" smooth="yes"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649"/>
-      <point x="1040" y="649" type="qcurve"/>
-      <point x="1036" y="672"/>
-      <point x="1026" y="708"/>
-      <point x="1020" y="725" type="qcurve" smooth="yes"/>
-      <point x="955" y="893"/>
-      <point x="730" y="1051"/>
-      <point x="576" y="1051" type="qcurve" smooth="yes"/>
-      <point x="341" y="1051"/>
-      <point x="50" y="744"/>
-      <point x="50" y="507" type="qcurve"/>
-      <point x="50" y="507" type="line"/>
-      <point x="50" y="265"/>
-      <point x="351" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="131" y="0" type="line"/>
-      <point x="349" y="0" type="line"/>
-      <point x="349" y="1432" type="line"/>
-      <point x="131" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="579" y="-33" type="qcurve" smooth="yes"/>
-      <point x="734" y="-33"/>
-      <point x="979" y="108"/>
-      <point x="1117" y="358"/>
-      <point x="1117" y="514" type="qcurve" smooth="yes"/>
-      <point x="1117" y="671"/>
-      <point x="977" y="919"/>
-      <point x="732" y="1057"/>
-      <point x="579" y="1057" type="qcurve" smooth="yes"/>
-      <point x="428" y="1057"/>
-      <point x="184" y="921"/>
-      <point x="43" y="674"/>
-      <point x="43" y="514" type="qcurve" smooth="yes"/>
-      <point x="43" y="358"/>
-      <point x="180" y="109"/>
-      <point x="425" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="579" y="157" type="qcurve" smooth="yes"/>
-      <point x="484" y="157"/>
-      <point x="337" y="253"/>
-      <point x="256" y="416"/>
-      <point x="256" y="514" type="qcurve" smooth="yes"/>
-      <point x="256" y="616"/>
-      <point x="343" y="777"/>
-      <point x="491" y="867"/>
-      <point x="579" y="867" type="qcurve" smooth="yes"/>
-      <point x="673" y="867"/>
-      <point x="821" y="773"/>
-      <point x="902" y="612"/>
-      <point x="902" y="514" type="qcurve" smooth="yes"/>
-      <point x="902" y="415"/>
-      <point x="821" y="252"/>
-      <point x="674" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -265,7 +265,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1050</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -271,7 +271,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -143,7 +143,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -267,7 +267,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="1002" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1355" y="-82"/>
-      <point x="1800" y="373"/>
-      <point x="1800" y="730" type="qcurve" smooth="yes"/>
-      <point x="1800" y="776"/>
-      <point x="1792" y="859"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902"/>
-      <point x="1785" y="902" type="qcurve"/>
-      <point x="1001" y="902" type="line"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902"/>
-      <point x="1001" y="902" type="qcurve"/>
-      <point x="1001" y="579" type="line"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579"/>
-      <point x="1001" y="579" type="qcurve"/>
-      <point x="1449" y="579" type="line"/>
-      <point x="1423" y="435"/>
-      <point x="1178" y="248"/>
-      <point x="1003" y="248" type="qcurve" smooth="yes"/>
-      <point x="797" y="248"/>
-      <point x="508" y="550"/>
-      <point x="508" y="750" type="qcurve" smooth="yes"/>
-      <point x="508" y="948"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
       <point x="796" y="1250"/>
-      <point x="1000" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1098" y="1250"/>
-      <point x="1261" y="1183"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127"/>
-      <point x="1319" y="1127" type="qcurve"/>
-      <point x="1558" y="1364" type="line"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364"/>
-      <point x="1558" y="1364" type="qcurve"/>
-      <point x="1450" y="1466"/>
-      <point x="1169" y="1582"/>
-      <point x="1002" y="1582" type="qcurve" smooth="yes"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
       <point x="655" y="1582"/>
-      <point x="170" y="1089"/>
-      <point x="170" y="750" type="qcurve" smooth="yes"/>
-      <point x="170" y="411"/>
-      <point x="652" y="-82"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1122"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="583" y="-31" type="qcurve" smooth="yes"/>
-      <point x="728" y="-31"/>
-      <point x="964" y="106"/>
-      <point x="1032" y="218" type="qcurve" smooth="yes"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218"/>
-      <point x="1032" y="218" type="qcurve"/>
-      <point x="870" y="324" type="line"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324"/>
-      <point x="870" y="324" type="qcurve" smooth="yes"/>
-      <point x="817" y="250"/>
-      <point x="675" y="168"/>
-      <point x="593" y="168" type="qcurve" smooth="yes"/>
-      <point x="456" y="168"/>
-      <point x="264" y="374"/>
-      <point x="264" y="520" type="qcurve"/>
-      <point x="264" y="520" type="line"/>
-      <point x="264" y="675"/>
-      <point x="430" y="866"/>
-      <point x="570" y="866" type="qcurve" smooth="yes"/>
-      <point x="652" y="866"/>
-      <point x="787" y="770"/>
-      <point x="825" y="663" type="qcurve"/>
-      <point x="844" y="754" type="line"/>
-      <point x="165" y="466" type="line"/>
-      <point x="222" y="301" type="line"/>
-      <point x="1042" y="649" type="line" smooth="yes"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649"/>
-      <point x="1042" y="649" type="qcurve"/>
-      <point x="1038" y="672"/>
-      <point x="1028" y="708"/>
-      <point x="1022" y="725" type="qcurve" smooth="yes"/>
-      <point x="957" y="893"/>
-      <point x="732" y="1051"/>
-      <point x="578" y="1051" type="qcurve" smooth="yes"/>
-      <point x="343" y="1051"/>
-      <point x="52" y="744"/>
-      <point x="52" y="507" type="qcurve"/>
-      <point x="52" y="507" type="line"/>
-      <point x="52" y="265"/>
-      <point x="353" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="553" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1061" y="-464"/>
-      <point x="1061" y="118" type="qcurve" smooth="yes"/>
-      <point x="1061" y="1020" type="line"/>
-      <point x="853" y="1020" type="line"/>
-      <point x="853" y="893" type="line"/>
-      <point x="849" y="893" type="line"/>
-      <point x="800" y="969"/>
-      <point x="626" y="1051"/>
-      <point x="522" y="1051" type="qcurve" smooth="yes"/>
-      <point x="376" y="1051"/>
-      <point x="157" y="913"/>
-      <point x="39" y="670"/>
-      <point x="39" y="517" type="qcurve" smooth="yes"/>
-      <point x="39" y="362"/>
-      <point x="157" y="123"/>
-      <point x="379" y="-11"/>
-      <point x="530" y="-11" type="qcurve" smooth="yes"/>
-      <point x="606" y="-11"/>
-      <point x="734" y="40"/>
-      <point x="822" y="113"/>
-      <point x="846" y="149" type="qcurve"/>
-      <point x="853" y="149" type="line"/>
-      <point x="853" y="56" type="line" smooth="yes"/>
-      <point x="853" y="-98"/>
-      <point x="698" y="-270"/>
-      <point x="550" y="-270" type="qcurve" smooth="yes"/>
-      <point x="453" y="-270"/>
-      <point x="319" y="-169"/>
-      <point x="272" y="-80" type="qcurve"/>
-      <point x="84" y="-163" type="line"/>
-      <point x="158" y="-320"/>
-      <point x="381" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="553" y="187" type="qcurve" smooth="yes"/>
-      <point x="466" y="187"/>
-      <point x="330" y="267"/>
-      <point x="253" y="419"/>
-      <point x="253" y="523" type="qcurve" smooth="yes"/>
-      <point x="253" y="622"/>
-      <point x="329" y="774"/>
-      <point x="465" y="857"/>
-      <point x="554" y="857" type="qcurve" smooth="yes"/>
-      <point x="645" y="857"/>
-      <point x="781" y="775"/>
-      <point x="853" y="624"/>
-      <point x="853" y="524" type="qcurve" smooth="yes"/>
-      <point x="853" y="426"/>
-      <point x="781" y="273"/>
-      <point x="645" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="134" y="0" type="line"/>
-      <point x="352" y="0" type="line"/>
-      <point x="352" y="1432" type="line"/>
-      <point x="134" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="582" y="-33" type="qcurve" smooth="yes"/>
-      <point x="737" y="-33"/>
-      <point x="982" y="108"/>
-      <point x="1120" y="358"/>
-      <point x="1120" y="514" type="qcurve" smooth="yes"/>
-      <point x="1120" y="671"/>
-      <point x="980" y="919"/>
-      <point x="735" y="1057"/>
-      <point x="582" y="1057" type="qcurve" smooth="yes"/>
-      <point x="431" y="1057"/>
-      <point x="187" y="921"/>
-      <point x="46" y="674"/>
-      <point x="46" y="514" type="qcurve" smooth="yes"/>
-      <point x="46" y="358"/>
-      <point x="183" y="109"/>
-      <point x="428" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="582" y="157" type="qcurve" smooth="yes"/>
-      <point x="487" y="157"/>
-      <point x="340" y="253"/>
-      <point x="259" y="416"/>
-      <point x="259" y="514" type="qcurve" smooth="yes"/>
-      <point x="259" y="616"/>
-      <point x="346" y="777"/>
-      <point x="494" y="867"/>
-      <point x="582" y="867" type="qcurve" smooth="yes"/>
-      <point x="676" y="867"/>
-      <point x="824" y="773"/>
-      <point x="905" y="612"/>
-      <point x="905" y="514" type="qcurve" smooth="yes"/>
-      <point x="905" y="415"/>
-      <point x="824" y="252"/>
-      <point x="677" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1020</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1590"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="822" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1030" y="-35"/>
-      <point x="1349" y="141"/>
-      <point x="1523" y="464"/>
-      <point x="1523" y="674" type="qcurve" smooth="yes"/>
-      <point x="1523" y="728"/>
-      <point x="1513" y="794" type="qcurve"/>
-      <point x="819" y="794" type="line"/>
-      <point x="819" y="587" type="line"/>
-      <point x="1306" y="587" type="line"/>
-      <point x="1293" y="454"/>
-      <point x="1165" y="268"/>
-      <point x="958" y="175"/>
-      <point x="827" y="175" type="qcurve" smooth="yes"/>
-      <point x="680" y="175"/>
-      <point x="444" y="313"/>
-      <point x="308" y="560"/>
-      <point x="308" y="717" type="qcurve" smooth="yes"/>
-      <point x="308" y="878"/>
-      <point x="445" y="1123"/>
-      <point x="681" y="1255"/>
-      <point x="827" y="1255" type="qcurve" smooth="yes"/>
-      <point x="942" y="1255"/>
-      <point x="1121" y="1179"/>
-      <point x="1206" y="1092" type="qcurve"/>
-      <point x="1351" y="1244" type="line"/>
-      <point x="1256" y="1356"/>
-      <point x="986" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="616" y="1464"/>
-      <point x="276" y="1269"/>
-      <point x="82" y="929"/>
-      <point x="82" y="720" type="qcurve" smooth="yes"/>
-      <point x="82" y="514"/>
-      <point x="277" y="170"/>
-      <point x="616" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_.super.glif
@@ -1,54 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1999"/>
+  <advance width="2000"/>
   <outline>
     <contour>
-      <point x="996" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1349" y="-82"/>
-      <point x="1794" y="373"/>
-      <point x="1794" y="730" type="qcurve" smooth="yes"/>
-      <point x="1794" y="776"/>
-      <point x="1786" y="859"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902"/>
-      <point x="1779" y="902" type="qcurve"/>
-      <point x="995" y="902" type="line"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902"/>
-      <point x="995" y="902" type="qcurve"/>
-      <point x="995" y="579" type="line"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579"/>
-      <point x="995" y="579" type="qcurve"/>
-      <point x="1443" y="579" type="line"/>
-      <point x="1417" y="435"/>
-      <point x="1172" y="248"/>
-      <point x="997" y="248" type="qcurve" smooth="yes"/>
-      <point x="791" y="248"/>
-      <point x="502" y="550"/>
-      <point x="502" y="750" type="qcurve" smooth="yes"/>
-      <point x="502" y="948"/>
-      <point x="790" y="1250"/>
-      <point x="994" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1092" y="1250"/>
-      <point x="1255" y="1183"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127"/>
-      <point x="1313" y="1127" type="qcurve"/>
-      <point x="1552" y="1364" type="line"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364"/>
-      <point x="1552" y="1364" type="qcurve"/>
-      <point x="1444" y="1466"/>
-      <point x="1163" y="1582"/>
-      <point x="996" y="1582" type="qcurve" smooth="yes"/>
-      <point x="649" y="1582"/>
-      <point x="164" y="1089"/>
-      <point x="164" y="750" type="qcurve" smooth="yes"/>
-      <point x="164" y="411"/>
-      <point x="646" y="-82"/>
+      <point x="998" y="-82" type="qcurve" smooth="yes"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
+      <point x="1796" y="730" type="qcurve" smooth="yes"/>
+      <point x="1796" y="776"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
+      <point x="1446" y="1466"/>
+      <point x="1166" y="1582"/>
+      <point x="998" y="1582" type="qcurve" smooth="yes"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
+      <point x="166" y="750" type="qcurve" smooth="yes"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6539"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1590"/>
-    <component base="o.logo" xOffset="2753"/>
-    <component base="g.logo" xOffset="3916"/>
-    <component base="l.logo" xOffset="5003"/>
-    <component base="e.logo" xOffset="5416"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1123"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="578" y="-31" type="qcurve" smooth="yes"/>
-      <point x="723" y="-31"/>
-      <point x="959" y="106"/>
-      <point x="1027" y="218" type="qcurve" smooth="yes"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218"/>
-      <point x="1027" y="218" type="qcurve"/>
-      <point x="865" y="324" type="line"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324"/>
-      <point x="865" y="324" type="qcurve" smooth="yes"/>
-      <point x="812" y="250"/>
-      <point x="670" y="168"/>
-      <point x="588" y="168" type="qcurve" smooth="yes"/>
-      <point x="451" y="168"/>
-      <point x="259" y="374"/>
-      <point x="259" y="520" type="qcurve"/>
-      <point x="259" y="520" type="line"/>
-      <point x="259" y="675"/>
-      <point x="425" y="866"/>
-      <point x="565" y="866" type="qcurve" smooth="yes"/>
-      <point x="647" y="866"/>
-      <point x="782" y="770"/>
-      <point x="820" y="663" type="qcurve"/>
-      <point x="839" y="754" type="line"/>
-      <point x="160" y="466" type="line"/>
-      <point x="217" y="301" type="line"/>
-      <point x="1037" y="649" type="line" smooth="yes"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649"/>
-      <point x="1037" y="649" type="qcurve"/>
-      <point x="1033" y="672"/>
-      <point x="1023" y="708"/>
-      <point x="1017" y="725" type="qcurve" smooth="yes"/>
-      <point x="952" y="893"/>
-      <point x="727" y="1051"/>
-      <point x="573" y="1051" type="qcurve" smooth="yes"/>
-      <point x="338" y="1051"/>
-      <point x="47" y="744"/>
-      <point x="47" y="507" type="qcurve"/>
-      <point x="47" y="507" type="line"/>
-      <point x="47" y="265"/>
-      <point x="348" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1087"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="547" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1055" y="-464"/>
-      <point x="1055" y="118" type="qcurve" smooth="yes"/>
-      <point x="1055" y="1020" type="line"/>
-      <point x="847" y="1020" type="line"/>
-      <point x="847" y="893" type="line"/>
-      <point x="843" y="893" type="line"/>
-      <point x="794" y="969"/>
-      <point x="620" y="1051"/>
-      <point x="516" y="1051" type="qcurve" smooth="yes"/>
-      <point x="370" y="1051"/>
-      <point x="151" y="913"/>
-      <point x="33" y="670"/>
-      <point x="33" y="517" type="qcurve" smooth="yes"/>
-      <point x="33" y="362"/>
-      <point x="151" y="123"/>
-      <point x="373" y="-11"/>
-      <point x="524" y="-11" type="qcurve" smooth="yes"/>
-      <point x="600" y="-11"/>
-      <point x="728" y="40"/>
-      <point x="816" y="113"/>
-      <point x="840" y="149" type="qcurve"/>
-      <point x="847" y="149" type="line"/>
-      <point x="847" y="56" type="line" smooth="yes"/>
-      <point x="847" y="-98"/>
-      <point x="692" y="-270"/>
-      <point x="544" y="-270" type="qcurve" smooth="yes"/>
-      <point x="447" y="-270"/>
-      <point x="313" y="-169"/>
-      <point x="266" y="-80" type="qcurve"/>
-      <point x="78" y="-163" type="line"/>
-      <point x="152" y="-320"/>
-      <point x="375" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="547" y="187" type="qcurve" smooth="yes"/>
-      <point x="460" y="187"/>
-      <point x="324" y="267"/>
-      <point x="247" y="419"/>
-      <point x="247" y="523" type="qcurve" smooth="yes"/>
-      <point x="247" y="622"/>
-      <point x="323" y="774"/>
-      <point x="459" y="857"/>
-      <point x="548" y="857" type="qcurve" smooth="yes"/>
-      <point x="639" y="857"/>
-      <point x="775" y="775"/>
-      <point x="847" y="624"/>
-      <point x="847" y="524" type="qcurve" smooth="yes"/>
-      <point x="847" y="426"/>
-      <point x="775" y="273"/>
-      <point x="639" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="413"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="128" y="0" type="line"/>
-      <point x="346" y="0" type="line"/>
-      <point x="346" y="1432" type="line"/>
-      <point x="128" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="731" y="-33"/>
-      <point x="976" y="108"/>
-      <point x="1114" y="358"/>
-      <point x="1114" y="514" type="qcurve" smooth="yes"/>
-      <point x="1114" y="671"/>
-      <point x="974" y="919"/>
-      <point x="729" y="1057"/>
-      <point x="576" y="1057" type="qcurve" smooth="yes"/>
-      <point x="425" y="1057"/>
-      <point x="181" y="921"/>
-      <point x="40" y="674"/>
-      <point x="40" y="514" type="qcurve" smooth="yes"/>
-      <point x="40" y="358"/>
-      <point x="177" y="109"/>
-      <point x="422" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="157" type="qcurve" smooth="yes"/>
-      <point x="481" y="157"/>
-      <point x="334" y="253"/>
-      <point x="253" y="416"/>
-      <point x="253" y="514" type="qcurve" smooth="yes"/>
-      <point x="253" y="616"/>
-      <point x="340" y="777"/>
-      <point x="488" y="867"/>
-      <point x="576" y="867" type="qcurve" smooth="yes"/>
-      <point x="670" y="867"/>
-      <point x="818" y="773"/>
-      <point x="899" y="612"/>
-      <point x="899" y="514" type="qcurve" smooth="yes"/>
-      <point x="899" y="415"/>
-      <point x="818" y="252"/>
-      <point x="671" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/fontinfo.plist
@@ -132,7 +132,7 @@
     <key>versionMajor</key>
     <integer>4</integer>
     <key>versionMinor</key>
-    <integer>3</integer>
+    <integer>4</integer>
     <key>xHeight</key>
     <integer>1086</integer>
   </dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,40 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="1592"/>
+  <advance width="1722"/>
   <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="828" y="-33" type="qcurve" smooth="yes"/>
-      <point x="1036" y="-35"/>
-      <point x="1355" y="141"/>
-      <point x="1529" y="464"/>
-      <point x="1529" y="674" type="qcurve" smooth="yes"/>
-      <point x="1529" y="728"/>
-      <point x="1519" y="794" type="qcurve"/>
-      <point x="825" y="794" type="line"/>
-      <point x="825" y="587" type="line"/>
-      <point x="1312" y="587" type="line"/>
-      <point x="1299" y="454"/>
-      <point x="1171" y="268"/>
-      <point x="964" y="175"/>
-      <point x="833" y="175" type="qcurve" smooth="yes"/>
-      <point x="686" y="175"/>
-      <point x="450" y="313"/>
-      <point x="314" y="560"/>
-      <point x="314" y="717" type="qcurve" smooth="yes"/>
-      <point x="314" y="878"/>
-      <point x="451" y="1123"/>
-      <point x="687" y="1255"/>
-      <point x="833" y="1255" type="qcurve" smooth="yes"/>
-      <point x="948" y="1255"/>
-      <point x="1127" y="1179"/>
-      <point x="1212" y="1092" type="qcurve"/>
-      <point x="1357" y="1244" type="line"/>
-      <point x="1262" y="1356"/>
-      <point x="992" y="1464"/>
-      <point x="830" y="1464" type="qcurve" smooth="yes"/>
-      <point x="622" y="1464"/>
-      <point x="282" y="1269"/>
-      <point x="88" y="929"/>
-      <point x="88" y="720" type="qcurve" smooth="yes"/>
-      <point x="88" y="514"/>
-      <point x="283" y="170"/>
-      <point x="622" y="-31"/>
+      <point x="920" y="-32" type="qcurve" smooth="yes"/>
+      <point x="1258" y="-32"/>
+      <point x="1686" y="386"/>
+      <point x="1686" y="722" type="qcurve" smooth="yes"/>
+      <point x="1686" y="753"/>
+      <point x="1679" y="822"/>
+      <point x="1674" y="862" type="qcurve"/>
+      <point x="920" y="862" type="line"/>
+      <point x="920" y="638" type="line"/>
+      <point x="1456" y="638" type="line"/>
+      <point x="1440" y="466"/>
+      <point x="1165" y="192"/>
+      <point x="920" y="192" type="qcurve" smooth="yes"/>
+      <point x="668" y="192"/>
+      <point x="332" y="543"/>
+      <point x="332" y="788" type="qcurve" smooth="yes"/>
+      <point x="332" y="1025"/>
+      <point x="667" y="1384"/>
+      <point x="920" y="1384" type="qcurve" smooth="yes"/>
+      <point x="1054" y="1384"/>
+      <point x="1252" y="1292"/>
+      <point x="1324" y="1224" type="qcurve"/>
+      <point x="1482" y="1382" type="line"/>
+      <point x="1382" y="1478"/>
+      <point x="1108" y="1608"/>
+      <point x="920" y="1608" type="qcurve" smooth="yes"/>
+      <point x="580" y="1608"/>
+      <point x="88" y="1119"/>
+      <point x="88" y="788" type="qcurve" smooth="yes"/>
+      <point x="88" y="459"/>
+      <point x="577" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_.super.glif
@@ -4,51 +4,35 @@
   <outline>
     <contour>
       <point x="998" y="-82" type="qcurve" smooth="yes"/>
-      <point x="1351" y="-82"/>
-      <point x="1796" y="373"/>
+      <point x="1345" y="-82"/>
+      <point x="1796" y="364"/>
       <point x="1796" y="730" type="qcurve" smooth="yes"/>
       <point x="1796" y="776"/>
-      <point x="1788" y="859"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902"/>
-      <point x="1781" y="902" type="qcurve"/>
-      <point x="997" y="902" type="line"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902"/>
-      <point x="997" y="902" type="qcurve"/>
-      <point x="997" y="579" type="line"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579"/>
-      <point x="997" y="579" type="qcurve"/>
-      <point x="1445" y="579" type="line"/>
-      <point x="1419" y="435"/>
-      <point x="1174" y="248"/>
-      <point x="999" y="248" type="qcurve" smooth="yes"/>
-      <point x="793" y="248"/>
-      <point x="504" y="550"/>
-      <point x="504" y="750" type="qcurve" smooth="yes"/>
-      <point x="504" y="948"/>
-      <point x="792" y="1250"/>
-      <point x="996" y="1250" type="qcurve" smooth="yes"/>
-      <point x="1094" y="1250"/>
-      <point x="1257" y="1183"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127"/>
-      <point x="1315" y="1127" type="qcurve"/>
-      <point x="1554" y="1364" type="line"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364"/>
-      <point x="1554" y="1364" type="qcurve"/>
+      <point x="1790" y="860"/>
+      <point x="1782" y="902" type="qcurve"/>
+      <point x="998" y="902" type="line"/>
+      <point x="998" y="580" type="line"/>
+      <point x="1446" y="580" type="line"/>
+      <point x="1420" y="436"/>
+      <point x="1184" y="248"/>
+      <point x="998" y="248" type="qcurve" smooth="yes"/>
+      <point x="801" y="248"/>
+      <point x="506" y="543"/>
+      <point x="506" y="750" type="qcurve" smooth="yes"/>
+      <point x="506" y="957"/>
+      <point x="796" y="1250"/>
+      <point x="998" y="1250" type="qcurve" smooth="yes"/>
+      <point x="1203" y="1250"/>
+      <point x="1316" y="1126" type="qcurve"/>
+      <point x="1554" y="1366" type="line"/>
       <point x="1446" y="1466"/>
-      <point x="1165" y="1582"/>
+      <point x="1166" y="1582"/>
       <point x="998" y="1582" type="qcurve" smooth="yes"/>
-      <point x="651" y="1582"/>
-      <point x="166" y="1089"/>
+      <point x="655" y="1582"/>
+      <point x="166" y="1083"/>
       <point x="166" y="750" type="qcurve" smooth="yes"/>
-      <point x="166" y="411"/>
-      <point x="648" y="-82"/>
+      <point x="166" y="417"/>
+      <point x="651" y="-82"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="6538"/>
+  <advance width="6568"/>
   <unicode hex="E006"/>
   <outline>
     <component base="G.logo"/>
-    <component base="o.logo" xOffset="1592"/>
-    <component base="o.logo" xOffset="2755"/>
-    <component base="g.logo" xOffset="3918"/>
-    <component base="l.logo" xOffset="5056"/>
-    <component base="e.logo" xOffset="5436"/>
+    <component base="o.logo" xOffset="1722"/>
+    <component base="o.logo" xOffset="2878"/>
+    <component base="g.logo" xOffset="4034"/>
+    <component base="l.logo" xOffset="5166"/>
+    <component base="e.logo" xOffset="5540"/>
   </outline>
   <lib>
     <dict>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="1102"/>
+  <advance width="1028"/>
   <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="563" y="-31" type="qcurve" smooth="yes"/>
-      <point x="708" y="-31"/>
-      <point x="944" y="106"/>
-      <point x="1012" y="218" type="qcurve" smooth="yes"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218"/>
-      <point x="1012" y="218" type="qcurve"/>
-      <point x="850" y="324" type="line"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324"/>
-      <point x="850" y="324" type="qcurve" smooth="yes"/>
-      <point x="797" y="250"/>
-      <point x="655" y="168"/>
-      <point x="573" y="168" type="qcurve" smooth="yes"/>
-      <point x="436" y="168"/>
-      <point x="244" y="374"/>
-      <point x="244" y="520" type="qcurve"/>
-      <point x="244" y="520" type="line"/>
-      <point x="244" y="675"/>
-      <point x="410" y="866"/>
-      <point x="550" y="866" type="qcurve" smooth="yes"/>
-      <point x="632" y="866"/>
-      <point x="767" y="770"/>
-      <point x="805" y="663" type="qcurve"/>
-      <point x="824" y="754" type="line"/>
-      <point x="145" y="466" type="line"/>
-      <point x="202" y="301" type="line"/>
-      <point x="1022" y="649" type="line" smooth="yes"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649"/>
-      <point x="1022" y="649" type="qcurve"/>
-      <point x="1018" y="672"/>
-      <point x="1008" y="708"/>
-      <point x="1002" y="725" type="qcurve" smooth="yes"/>
-      <point x="937" y="893"/>
-      <point x="712" y="1051"/>
-      <point x="558" y="1051" type="qcurve" smooth="yes"/>
-      <point x="323" y="1051"/>
-      <point x="32" y="744"/>
-      <point x="32" y="507" type="qcurve"/>
-      <point x="32" y="507" type="line"/>
-      <point x="32" y="265"/>
-      <point x="333" y="-31"/>
+      <point x="578" y="-32" type="qcurve" smooth="yes"/>
+      <point x="700" y="-32"/>
+      <point x="874" y="50"/>
+      <point x="990" y="160"/>
+      <point x="1018" y="202" type="qcurve"/>
+      <point x="838" y="322" type="line"/>
+      <point x="794" y="256"/>
+      <point x="666" y="176"/>
+      <point x="578" y="176" type="qcurve" smooth="yes"/>
+      <point x="464" y="176"/>
+      <point x="282" y="337"/>
+      <point x="282" y="498" type="qcurve" smooth="yes"/>
+      <point x="282" y="653"/>
+      <point x="452" y="820"/>
+      <point x="560" y="820" type="qcurve" smooth="yes"/>
+      <point x="630" y="820"/>
+      <point x="736" y="758"/>
+      <point x="756" y="708" type="qcurve"/>
+      <point x="200" y="476" type="line"/>
+      <point x="242" y="302" type="line"/>
+      <point x="1028" y="628" type="line"/>
+      <point x="1000" y="698" type="line" smooth="yes"/>
+      <point x="957" y="805"/>
+      <point x="735" y="1024"/>
+      <point x="552" y="1024" type="qcurve" smooth="yes"/>
+      <point x="340" y="1024"/>
+      <point x="54" y="722"/>
+      <point x="54" y="496" type="qcurve" smooth="yes"/>
+      <point x="54" y="270"/>
+      <point x="361" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,54 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="1138"/>
+  <advance width="1132"/>
   <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="550" y="-464" type="qcurve" smooth="yes"/>
-      <point x="1058" y="-464"/>
-      <point x="1058" y="118" type="qcurve" smooth="yes"/>
-      <point x="1058" y="1020" type="line"/>
-      <point x="850" y="1020" type="line"/>
-      <point x="850" y="893" type="line"/>
-      <point x="846" y="893" type="line"/>
-      <point x="797" y="969"/>
-      <point x="623" y="1051"/>
-      <point x="519" y="1051" type="qcurve" smooth="yes"/>
-      <point x="373" y="1051"/>
-      <point x="154" y="913"/>
-      <point x="36" y="670"/>
-      <point x="36" y="517" type="qcurve" smooth="yes"/>
-      <point x="36" y="362"/>
-      <point x="154" y="123"/>
-      <point x="376" y="-11"/>
-      <point x="527" y="-11" type="qcurve" smooth="yes"/>
-      <point x="603" y="-11"/>
-      <point x="731" y="40"/>
-      <point x="819" y="113"/>
-      <point x="843" y="149" type="qcurve"/>
-      <point x="850" y="149" type="line"/>
-      <point x="850" y="56" type="line" smooth="yes"/>
-      <point x="850" y="-98"/>
-      <point x="695" y="-270"/>
-      <point x="547" y="-270" type="qcurve" smooth="yes"/>
-      <point x="450" y="-270"/>
-      <point x="316" y="-169"/>
-      <point x="269" y="-80" type="qcurve"/>
-      <point x="81" y="-163" type="line"/>
-      <point x="155" y="-320"/>
-      <point x="378" y="-464"/>
+      <point x="554" y="-506" type="qcurve" smooth="yes"/>
+      <point x="792" y="-506"/>
+      <point x="1056" y="-216"/>
+      <point x="1056" y="44" type="qcurve" smooth="yes"/>
+      <point x="1056" y="992" type="line"/>
+      <point x="836" y="992" type="line"/>
+      <point x="836" y="906" type="line"/>
+      <point x="828" y="906" type="line"/>
+      <point x="790" y="952"/>
+      <point x="644" y="1024"/>
+      <point x="550" y="1024" type="qcurve" smooth="yes"/>
+      <point x="353" y="1024"/>
+      <point x="44" y="720"/>
+      <point x="44" y="494" type="qcurve" smooth="yes"/>
+      <point x="44" y="268"/>
+      <point x="357" y="-32"/>
+      <point x="550" y="-32" type="qcurve" smooth="yes"/>
+      <point x="644" y="-32"/>
+      <point x="790" y="40"/>
+      <point x="828" y="88" type="qcurve"/>
+      <point x="836" y="88" type="line"/>
+      <point x="836" y="12" type="line" smooth="yes"/>
+      <point x="836" y="-140"/>
+      <point x="684" y="-298"/>
+      <point x="554" y="-298" type="qcurve" smooth="yes"/>
+      <point x="451" y="-298"/>
+      <point x="314" y="-177"/>
+      <point x="288" y="-110" type="qcurve"/>
+      <point x="86" y="-194" type="line"/>
+      <point x="130" y="-306"/>
+      <point x="375" y="-506"/>
     </contour>
     <contour>
-      <point x="550" y="187" type="qcurve" smooth="yes"/>
-      <point x="463" y="187"/>
-      <point x="327" y="267"/>
-      <point x="250" y="419"/>
-      <point x="250" y="523" type="qcurve" smooth="yes"/>
-      <point x="250" y="622"/>
-      <point x="326" y="774"/>
-      <point x="462" y="857"/>
-      <point x="551" y="857" type="qcurve" smooth="yes"/>
-      <point x="642" y="857"/>
-      <point x="778" y="775"/>
-      <point x="850" y="624"/>
-      <point x="850" y="524" type="qcurve" smooth="yes"/>
-      <point x="850" y="426"/>
-      <point x="778" y="273"/>
-      <point x="642" y="187"/>
+      <point x="570" y="176" type="qcurve" smooth="yes"/>
+      <point x="447" y="176"/>
+      <point x="276" y="358"/>
+      <point x="276" y="494" type="qcurve" smooth="yes"/>
+      <point x="276" y="630"/>
+      <point x="448" y="816"/>
+      <point x="570" y="816" type="qcurve" smooth="yes"/>
+      <point x="692" y="816"/>
+      <point x="852" y="626"/>
+      <point x="852" y="494" type="qcurve" smooth="yes"/>
+      <point x="852" y="362"/>
+      <point x="693" y="176"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="380"/>
+  <advance width="374"/>
   <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="81" y="0" type="line"/>
-      <point x="299" y="0" type="line"/>
-      <point x="299" y="1432" type="line"/>
-      <point x="81" y="1432" type="line"/>
+      <point x="84" y="0" type="line"/>
+      <point x="316" y="0" type="line"/>
+      <point x="316" y="1552" type="line"/>
+      <point x="84" y="1552" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,35 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="1163"/>
+  <advance width="1156"/>
   <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="580" y="-33" type="qcurve" smooth="yes"/>
-      <point x="735" y="-33"/>
-      <point x="980" y="108"/>
-      <point x="1118" y="358"/>
-      <point x="1118" y="514" type="qcurve" smooth="yes"/>
-      <point x="1118" y="671"/>
-      <point x="978" y="919"/>
-      <point x="733" y="1057"/>
-      <point x="580" y="1057" type="qcurve" smooth="yes"/>
-      <point x="429" y="1057"/>
-      <point x="185" y="921"/>
-      <point x="44" y="674"/>
-      <point x="44" y="514" type="qcurve" smooth="yes"/>
-      <point x="44" y="358"/>
-      <point x="181" y="109"/>
-      <point x="426" y="-33"/>
+      <point x="574" y="-32" type="qcurve" smooth="yes"/>
+      <point x="782" y="-32"/>
+      <point x="1104" y="261"/>
+      <point x="1104" y="496" type="qcurve" smooth="yes"/>
+      <point x="1104" y="731"/>
+      <point x="783" y="1024"/>
+      <point x="574" y="1024" type="qcurve" smooth="yes"/>
+      <point x="365" y="1024"/>
+      <point x="44" y="731"/>
+      <point x="44" y="496" type="qcurve" smooth="yes"/>
+      <point x="44" y="261"/>
+      <point x="366" y="-32"/>
     </contour>
     <contour>
-      <point x="580" y="157" type="qcurve" smooth="yes"/>
-      <point x="485" y="157"/>
-      <point x="338" y="253"/>
-      <point x="257" y="416"/>
-      <point x="257" y="514" type="qcurve" smooth="yes"/>
-      <point x="257" y="616"/>
-      <point x="344" y="777"/>
-      <point x="492" y="867"/>
-      <point x="580" y="867" type="qcurve" smooth="yes"/>
-      <point x="674" y="867"/>
-      <point x="822" y="773"/>
-      <point x="903" y="612"/>
-      <point x="903" y="514" type="qcurve" smooth="yes"/>
-      <point x="903" y="415"/>
-      <point x="822" y="252"/>
-      <point x="675" y="157"/>
+      <point x="574" y="176" type="qcurve" smooth="yes"/>
+      <point x="451" y="176"/>
+      <point x="276" y="354"/>
+      <point x="276" y="496" type="qcurve" smooth="yes"/>
+      <point x="276" y="638"/>
+      <point x="450" y="816"/>
+      <point x="574" y="816" type="qcurve" smooth="yes"/>
+      <point x="698" y="816"/>
+      <point x="872" y="638"/>
+      <point x="872" y="496" type="qcurve" smooth="yes"/>
+      <point x="872" y="354"/>
+      <point x="697" y="176"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Everything else, but the version number and the usual suspects should stay as 4.003 release.