### PR TITLE
Harden GitHub Actions against script injection

### DIFF
--- a/.github/actions/create-import-branch/action.yml
+++ b/.github/actions/create-import-branch/action.yml
@@ -23,9 +23,13 @@ runs:
     - name: Log inputs
       shell: bash
       run: |
-        echo "updated-sources: ${{ inputs.updated-sources }}"
-        echo "imported-branch: ${{ inputs.imported-branch }}"
-        echo "git-email: ${{ inputs.git-email }}"
+        echo "updated-sources: ${INPUTS_UPDATED_SOURCES}"
+        echo "imported-branch: ${INPUTS_IMPORTED_BRANCH}"
+        echo "git-email: ${INPUTS_GIT_EMAIL}"
+      env:
+        INPUTS_UPDATED_SOURCES: ${{ inputs.updated-sources }}
+        INPUTS_IMPORTED_BRANCH: ${{ inputs.imported-branch }}
+        INPUTS_GIT_EMAIL: ${{ inputs.git-email }}
     - name: Create/Checkout branch
       shell: bash
       env:
@@ -52,23 +56,28 @@ runs:
       run: |
         shopt -s dotglob
         rm -r target/sources
-        mv --no-clobber "${{ inputs.updated-sources }}"/sources target/
+        mv --no-clobber "${INPUTS_UPDATED_SOURCES}"/sources target/
+      env:
+        INPUTS_UPDATED_SOURCES: ${{ inputs.updated-sources }}
     - name: Update the design sources
       shell: bash
       run: |
         # sources/design-source was deleted by the rm in the previous step
         cd target
-        git checkout "origin/${{ inputs.imported-branch }}" -- sources/design-source
+        git checkout "origin/${INPUTS_IMPORTED_BRANCH}" -- sources/design-source
+      env:
+        INPUTS_IMPORTED_BRANCH: ${{ inputs.imported-branch }}
     - name: Commit, rebase, and push changes
       id: commit-rebase-push
       shell: bash
       env:
         SOURCE_BRANCH: ${{ inputs.imported-branch }}
         TARGET_BRANCH: ${{ format('import-{0}', inputs.imported-branch) }}
+        INPUTS_GIT_EMAIL: ${{ inputs.git-email }}
       run: |
         cd target
         git config user.name "Import Script"
-        git config user.email ${{ inputs.git-email }}
+        git config user.email ${INPUTS_GIT_EMAIL}
         git add sources
         # git commit returns non-zero if there's nothing to commit, and GitHub
         # runs scripts with exit on error, so we need to suppress this with

--- a/.github/actions/cut-workspace-fonts/action.yml
+++ b/.github/actions/cut-workspace-fonts/action.yml
@@ -16,7 +16,9 @@ runs:
   steps:
   - name: Log inputs
     shell: bash
-    run: 'echo "vf-artifact: ${{ inputs.vf-artifact }}"'
+    run: 'echo "vf-artifact: ${INPUTS_VF_ARTIFACT}"'
+    env:
+      INPUTS_VF_ARTIFACT: ${{ inputs.vf-artifact }}
   - name: Download main VF
     uses: actions/download-artifact@v7
     with:

--- a/.github/actions/glyphspackage2ufo/action.yml
+++ b/.github/actions/glyphspackage2ufo/action.yml
@@ -57,10 +57,12 @@ runs:
       # glyphspackage2ufo-XXXX created above and passed through the GitHub
       # output target=, because it's been prepared to NOT have leftover UFOs
       # which is required to be able to emit a clean DS+UFOs
-      cd "${{ steps.prepare-import.outputs.target }}"
+      cd "${STEPS_PREPARE_IMPORT_OUTPUTS_TARGET}"
       echo "Running glyphs_to_ds.py"
       uv run --quiet --python $(cat .github/workflows/python-version.txt) \
         --with-requirements requirements.txt \
         scripts/glyphs_to_ds.py \
         "$GITHUB_WORKSPACE/octavio/sources/design-source/GSF-full.glyphspackage" \
         --output sources/GoogleSansFlex.designspace
+    env:
+      STEPS_PREPARE_IMPORT_OUTPUTS_TARGET: ${{ steps.prepare-import.outputs.target }}

--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -23,12 +23,15 @@ jobs:
         path: main
     - name: Log & validate inputs
       run: |
-        echo "git-ref: ${{ github.event.inputs.git-ref }}"
+        echo "git-ref: ${INPUT_GIT_REF}"
         echo "python-version-file: $(head -n 1 -z ./main/.github/workflows/python-version.txt)"
-        if [[ "${{ github.ref_name }}" != "main" ]]; then
+        if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
           echo "::error title=Pipeline not run on main::Build from Glyphs workflow should always be run from main"
           exit 1
         fi
+      env:
+        INPUT_GIT_REF: ${{ github.event.inputs.git-ref }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -41,9 +44,11 @@ jobs:
     - name: Create sources tarball
       shell: bash
       run: |
-        cd "${{ steps.glyphspackage2ufo.outputs.directory }}"
+        cd "${SOURCES_DIR}"
         shopt -s dotglob
         tar --create --exclude-vcs --file "UFO sources.tar" *
+      env:
+        SOURCES_DIR: ${{ steps.glyphspackage2ufo.outputs.directory }}
     - name: Generate sources artifact name
       id: zip-name
       uses: alpha-tango-kilo/gha-artifact-name@v1

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: Run diffenator3
       run: |
         mkdir -p diffenator_report
-        if [[ ${{ inputs.all-masters }} == "true" ]] ; then
+        if [[ "${INPUT_ALL_MASTERS}" == "true" ]] ; then
           echo "Checking masters"
           LOCATIONS_ARG="--masters"
         else
@@ -100,6 +100,8 @@ jobs:
         fi
         diffenator3 before/*.ttf after/*.ttf \
           $LOCATIONS_ARG --html --output diffenator_report
+      env:
+        INPUT_ALL_MASTERS: ${{ inputs.all-masters }}
     - name: Upload diffenator report
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -25,13 +25,17 @@ jobs:
           path: main
       - name: Log & validate inputs
         run: |
-          echo "git-ref: ${{ github.event.inputs.git-ref }}"
-          echo "git-email: ${{ github.event.inputs.email }}"
+          echo "git-ref: ${INPUT_GIT_REF}"
+          echo "git-email: ${INPUT_EMAIL}"
           echo "python-version-file: $(head -n 1 -z ./main/.github/workflows/python-version.txt)"
-          if [[ "${{ github.ref_name }}" != "main" ]]; then
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
             echo "::error title=Pipeline not run on main::Import workflow should always be run from main"
             exit 1
           fi
+        env:
+          INPUT_GIT_REF: ${{ github.event.inputs.git-ref }}
+          INPUT_EMAIL: ${{ github.event.inputs.email }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
       - name: Convert Glyphs package sources to UFO
         id: glyphspackage2ufo
         uses: ./main/.github/actions/glyphspackage2ufo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,30 +197,35 @@ jobs:
         #       when uploading to the release
         variable_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/}.zip"
         echo "variable-zip-name=$variable_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.build-variable.outputs.artifact-name }}" \
+        cd "$GITHUB_WORKSPACE/${VARIABLE_ARTIFACT}" \
           && zip -9 "../$variable_zip_name" *.ttf
 
         workspace_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} workspace.zip"
         echo "workspace-zip-name=$workspace_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}/workspace" \
+        cd "$GITHUB_WORKSPACE/${WORKSPACE_ARTIFACT}/workspace" \
           && zip -9 "../../$workspace_zip_name" *.ttf *.md
 
         tv_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} tv.zip"
         echo "tv-zip-name=$tv_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}/tv" \
+        cd "$GITHUB_WORKSPACE/${WORKSPACE_ARTIFACT}/tv" \
           && zip -9 "../../$tv_zip_name" *.ttf *.md
 
         figma_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} figma.zip"
         echo "figma-zip-name=$figma_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.figma-artifact-name }}" \
+        cd "$GITHUB_WORKSPACE/${FIGMA_ARTIFACT}" \
           && zip -9 "../$figma_zip_name" *.ttf *.md
 
         android_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} Android.zip"
         echo "android-zip-name=$android_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.android-artifact-name }}"
+        cd "$GITHUB_WORKSPACE/${ANDROID_ARTIFACT}"
         # Rename file to match what Android's already using (regardless as to how representative the name is)
         mv GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf GoogleSansFlex-Regular.ttf
         zip -9 "../$android_zip_name" *.ttf *.md
+      env:
+        VARIABLE_ARTIFACT: ${{ needs.build-variable.outputs.artifact-name }}
+        WORKSPACE_ARTIFACT: ${{ needs.cut-instances.outputs.workspace-artifact-name }}
+        FIGMA_ARTIFACT: ${{ needs.cut-instances.outputs.figma-artifact-name }}
+        ANDROID_ARTIFACT: ${{ needs.cut-instances.outputs.android-artifact-name }}
     - name: Upload variable font archive to release
       uses: svenstaro/upload-release-action@v2
       with:


### PR DESCRIPTION
## Summary

- Replace `${{ }}` expression interpolation in `run:` blocks with environment variables to prevent script injection attacks
- Applies the same security hardening as googlefonts/fontc#1896 to this repo's workflows
- Affected workflows: `build-glyphs.yml`, `diffenator.yaml`, `import.yaml`, `release.yml`

## Test plan

- [x] Verify `Build from Glyphs package` workflow still works (manual trigger)
- [x] Verify `Diffenate builds` workflow still works (manual trigger)
- [x] Verify `Update from sources` import workflow still works (manual trigger)
- [x] Verify release workflow works on next release
