### PR TITLE
Exclude `googlefonts/family_name_compliance`

### DIFF
--- a/qa/check-googlesans.toml
+++ b/qa/check-googlesans.toml
@@ -31,4 +31,5 @@ exclude_checks = [
     "STAT_strings",                                    # we're intentionally calling slant italic https://github.com/googlefonts/googlesans-flex/issues/774#issuecomment-1921326716
     "unwanted_tables",
     "family/uniqueness_first_31_characters",           # flags on Android fonts and not a concern of ours https://chat.google.com/room/AAAAgistbQI/wlaUyu_h9PQ/QoPtBiX27sY?cls=10
+    "googlefonts/family_name_compliance",
 ]


### PR DESCRIPTION
Will resolve the failing release pipeline that currently doesn't like some of the workspace fonts

See: https://github.com/googlefonts/googlesans-flex/actions/runs/28394311121